### PR TITLE
Fixes  RT#92464: Class::MOP::load_class deprecation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,7 +8,7 @@ all_from 'lib/Cantella/Store/UUID.pm';
 
 requires 'JSON';
 requires 'Moose';
-requires 'Class::MOP';
+requires 'Class::Load' => '0.20';
 requires 'File::Copy';
 requires 'Data::GUID';
 requires 'Path::Class' => '0.18';

--- a/lib/Cantella/Store/UUID.pm
+++ b/lib/Cantella/Store/UUID.pm
@@ -2,7 +2,7 @@ package Cantella::Store::UUID;
 
 use Moose;
 use Try::Tiny;
-use Class::MOP;
+use Class::Load;
 use Data::GUID;
 use File::Copy qw();
 use Path::Class qw();
@@ -32,7 +32,7 @@ has file_class => (
   isa => 'ClassName',
   required => 1,
   default => sub {
-    Class::MOP::load_class('Cantella::Store::UUID::File');
+    Class::Load::load_class('Cantella::Store::UUID::File');
     return 'Cantella::Store::UUID::File';
   }
 );


### PR DESCRIPTION
This fixes RT#92464:  deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=92464
